### PR TITLE
Proper packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ adds/removes/reopens files as they are created, deleted, and rotated."""
    ,  author = 'Derp Ston'
    ,  author_email = 'derpston+pypi@sleepygeek.org'
    ,  url = 'https://github.com/derpston/python-multitail2'
-   ,  packages = ['']
+   ,  packages = []
    ,  package_dir = {'': 'src'}
    )
 


### PR DESCRIPTION
Fixes

```
  Running setup.py install for multitail2
    WARNING: '' not a valid package name; please use only.-separated package names in setup.py
```
