### PR TITLE
Explicitly close deleted files to avoid leaking

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+python-multitail2 (1.4.1) unstable; urgency=low
+  
+  * Explicitly closed deleted files..
+
+ -- Derp Ston <derpston+packaging@sleepygeek.org>  Mon, 2 Nov 2017 14:30:00 +0000
 python-multitail2 (1.4.0) unstable; urgency=low
   
   * Fixing a bug where lines longer than 65k would prevent reading further.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 
 setup(
       name = 'multitail2'
-   ,  version = '1.4.0'
+   ,  version = '1.4.1'
    ,  description = 'Enables following multiple files for new lines at once, automatically handling file creation/deletion/rotation'
    ,  long_description = """Accepts a glob spec like '/var/log/*.log' and \
 adds/removes/reopens files as they are created, deleted, and rotated."""

--- a/src/multitail2.py
+++ b/src/multitail2.py
@@ -4,7 +4,7 @@ import logging
 import os
 import random
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 logger = logging.getLogger(__name__)
 
 class TailedFile:
@@ -53,6 +53,9 @@ class TailedFile:
       # take the None argument or have any way to specify "read to the end".
       # This emulates that behaviour.
       while True:
+         # Check that we haven't closed this file
+         if not self._fh:
+            return False
          dataread = os.read(self._fh.fileno(), limit or 65535)
          if len(dataread) > 0:
             self._buf += dataread


### PR DESCRIPTION
It seems like we're not correctly handling the situation where files are
deleted, and they're kept open for as long as the process is running.

This is probably because we're relying on an implicit `close()`
happening on the file object when the `TailedFile` object gets garbage
collected, but we don't necessarily have control about this (and it
doesn't seem to happen, hinting at other references pointing to it).

This PR adds and explicit `_close()` method to ensure we no longer need
to rely in this implicit behaviour.